### PR TITLE
Don't trigger a compilation when saving model to pin

### DIFF
--- a/VL.Kairos.Runtime/vl/VL.Kairos.Runtime.Core.vl
+++ b/VL.Kairos.Runtime/vl/VL.Kairos.Runtime.Core.vl
@@ -14504,11 +14504,6 @@
                 <Pin Id="OkpMjsJqeuuOgMkuAcn8Wv" Name="Value" Kind="InputPin" />
                 <Pin Id="M8RwJTuMAcdPY2vu6RtZpi" Name="Solution Update Kind" Kind="InputPin" />
               </Node>
-              <Pad Id="UTWSRyQSJ0hQHHZXNBu0Bv" Comment="Solution Update Kind" Bounds="285,1008,132,15" ShowValueBox="true" isIOBox="true" Value="Default">
-                <p:TypeAnnotation LastCategoryFullName="VL.Model" LastDependency="VL.Core.dll">
-                  <Choice Kind="TypeFlag" Name="SolutionUpdateKind" />
-                </p:TypeAnnotation>
-              </Pad>
               <ControlPoint Id="CNU6Kg4MbA7PbAZLu6Fede" Bounds="536,122" />
               <Overlay Id="OxGpo8opSwkLXJGQ9q6ktf" Name="Write" Bounds="110,632,440,453">
                 <p:ColorIndex p:Type="Int32">11</p:ColorIndex>
@@ -14661,7 +14656,6 @@
             <Link Id="AiE7aSfsydnPdgPj0LmdwU" Ids="MVU4KX8LCVlNRdOId3N1TG,FUOiMeK3XsjP9P9vRe5Tak" IsHidden="true" />
             <Link Id="QE0f4YhVUMrPc2iSlxlIQn" Ids="ONddrKrbORXN65YmzCvcPq,DRkyg4fkwPbMsWHFysJAmz" />
             <Link Id="PIRQEavFuIdPhpwZprqCVs" Ids="LxPadwBEh0CLrt4QrA2MNY,ONddrKrbORXN65YmzCvcPq" IsHidden="true" />
-            <Link Id="KkKP6jnUIwUPe0neTwmLT3" Ids="UTWSRyQSJ0hQHHZXNBu0Bv,M8RwJTuMAcdPY2vu6RtZpi" />
             <Link Id="DZT9Nh9EdfFQJV33JZJtSN" Ids="Ug877ajbTnzNWbviO9bSZo,CNU6Kg4MbA7PbAZLu6Fede" IsHidden="true" />
             <Slot Id="PRFYqIxua86MXROMjoCVnz" Name="Node Context" />
             <Link Id="LoUeBKGwa9yMKSzWxWVXeI" Ids="CNU6Kg4MbA7PbAZLu6Fede,Km9bBrQVmc3OUwa6PAG4uE" />


### PR DESCRIPTION
6.0 does a couple of things better in that regard. We probably had to force a compilation in 5.x because it wouldn't pick up the fresh model after a restart. Now with 6.0 this is no longer necessary. Feels a bit nicer that way, machine doing far less.